### PR TITLE
Add item-metadata based SE option to cac_rud

### DIFF
--- a/R/cac_rud.R
+++ b/R/cac_rud.R
@@ -8,14 +8,16 @@
 #'
 #' @inheritParams cac_lee
 #' @param se A numeric vector of the same length as `theta` representing the
-#'   standard errors associated with each ability estimate. See the **Details**
-#'   section for more information
+#'   standard errors associated with each ability estimate. If omitted and
+#'   `x` is supplied, standard errors are computed using the test information
+#'   function. See the **Details** section for more information
 #'
 #' @details This function first validates the input arguments. If both `theta`
 #' and `weights` are `NULL`, the function will stop and return an error message.
-#' Either `theta` or `weights` must be specified. In addition, `se` must be
-#' provided and must match the length of `theta` or the number of quadrature
-#' points in `weights`.
+#' Either `theta` or `weights` must be specified. If `se` is not provided, it
+#' will be computed from the test information based on the item metadata `x`.
+#' The length of `se` must match the length of `theta` or the number of
+#' quadrature points in `weights`.
 #'
 #' It then computes the probability that an examinee with a given ability is
 #' classified into each performance level using the normal distribution function
@@ -66,12 +68,8 @@
 #' node <- seq(-4, 4, 0.25)
 #' weights <- gen.weight(dist = "norm", mu = 0, sigma = 1, theta = node)
 #'
-#' # Compute conditional standard errors across quadrature points
-#' tif <- info(x = x, theta = node, D = 1, tif = TRUE)$tif
-#' se <- 1 / sqrt(tif)
-#'
 #' # Compute classification accuracy and consistency
-#' cac_1 <- cac_rud(cutscore = cutscore, se = se, weights = weights)
+#' cac_1 <- cac_rud(x = x, cutscore = cutscore, weights = weights, D = 1)
 #' print(cac_1)
 #'
 #' ## -----------------------------------------
@@ -93,28 +91,37 @@
 #' theta_hat <- est_theta$est.theta
 #' se <- est_theta$se.theta
 #'
-#' # Compute classification accuracy and consistency
-#' cac_2 <- cac_rud(cutscore = cutscore, theta = theta_hat, se = se)
+#' # Compute classification accuracy and consistency using provided SEs
+#' cac_2 <- cac_rud(x = x, cutscore = cutscore, theta = theta_hat, se = se)
 #' print(cac_2)
 #' }
 #'
 #' @import dplyr
 #' @export
-cac_rud <- function(cutscore,
+cac_rud <- function(x = NULL,
+                    cutscore,
                     theta = NULL,
-                    se,
-                    weights = NULL) {
-
-  # check if the provided inputs are correct
-  if (missing(se)) {
-    stop("The standard errors must be provided in `se` argument.", call. = FALSE)
-  }
+                    se = NULL,
+                    weights = NULL,
+                    D = 1) {
 
   # check if the provided inputs are correct
   if (is.null(theta) & is.null(weights)) {
     stop("Eighter of `theta` or `weights` argument must not be NULL; both cannot be NULL",
          call. = FALSE
     )
+  }
+
+  # compute standard errors if not provided
+  if (is.null(se)) {
+    if (is.null(x)) {
+      stop("Either `se` or `x` argument must be supplied.", call. = FALSE)
+    }
+    if (!is.null(weights)) {
+      se <- 1 / sqrt(info(x = x, theta = weights[, 1], D = D, tif = TRUE)$tif)
+    } else {
+      se <- 1 / sqrt(info(x = x, theta = theta, D = D, tif = TRUE)$tif)
+    }
   }
 
   # count the number of levels

--- a/man/cac_rud.Rd
+++ b/man/cac_rud.Rd
@@ -5,9 +5,14 @@
 \title{Classification Accuracy and Consistency Based on Rudner's (2001, 2005)
 Approach}
 \usage{
-cac_rud(cutscore, theta = NULL, se, weights = NULL)
+cac_rud(x = NULL, cutscore, theta = NULL, se = NULL, weights = NULL,
+  D = 1)
 }
 \arguments{
+\item{x}{A data frame containing item metadata. If provided and \code{se} is
+  \code{NULL}, standard errors are computed from the test information
+  function.}
+
 \item{cutscore}{A numeric vector specifying the cut scores for
 classification. Cut scores are the points that separate different
 performance categories (e.g., pass vs. fail, or different grades).}
@@ -17,13 +22,16 @@ values) are the individual proficiency estimates obtained from the IRT
 model. The theta parameter is optional and can be \code{NULL}.}
 
 \item{se}{A numeric vector of the same length as \code{theta} representing the
-standard errors associated with each ability estimate. See the \strong{Details}
-section for more information}
+standard errors associated with each ability estimate. If omitted, and
+\code{x} is provided, these values are computed using the test information
+function. See the \strong{Details} section for more information}
 
 \item{weights}{An optional two-column data frame or matrix where the first
 column is the quadrature points (nodes) and the second column is the
 corresponding weights. This is typically used in quadrature-based IRT
 analysis.}
+
+\item{D}{A scaling constant used in IRT models. Default is 1.}
 }
 \value{
 A list containing the following elements:
@@ -44,9 +52,10 @@ available, and when individual ability estimates are used.
 \details{
 This function first validates the input arguments. If both \code{theta}
 and \code{weights} are \code{NULL}, the function will stop and return an error message.
-Either \code{theta} or \code{weights} must be specified. In addition, \code{se} must be
-provided and must match the length of \code{theta} or the number of quadrature
-points in \code{weights}.
+Either \code{theta} or \code{weights} must be specified. If \code{se} is
+omitted, it will be computed from the test information using item metadata
+\code{x}. The length of \code{se} must match the length of \code{theta} or the
+number of quadrature points in \code{weights}.
 
 It then computes the probability that an examinee with a given ability is
 classified into each performance level using the normal distribution function
@@ -79,12 +88,8 @@ cutscore <- c(-2, -0.5, 0.8)
 node <- seq(-4, 4, 0.25)
 weights <- gen.weight(dist = "norm", mu = 0, sigma = 1, theta = node)
 
-# Compute conditional standard errors across quadrature points
-tif <- info(x = x, theta = node, D = 1, tif = TRUE)$tif
-se <- 1 / sqrt(tif)
-
 # Compute classification accuracy and consistency
-cac_1 <- cac_rud(cutscore = cutscore, se = se, weights = weights)
+cac_1 <- cac_rud(x = x, cutscore = cutscore, weights = weights, D = 1)
 print(cac_1)
 
 ## -----------------------------------------
@@ -106,8 +111,8 @@ est_theta <- est_score(
 theta_hat <- est_theta$est.theta
 se <- est_theta$se.theta
 
-# Compute classification accuracy and consistency
-cac_2 <- cac_rud(cutscore = cutscore, theta = theta_hat, se = se)
+# Compute classification accuracy and consistency using provided SEs
+cac_2 <- cac_rud(x = x, cutscore = cutscore, theta = theta_hat, se = se)
 print(cac_2)
 }
 


### PR DESCRIPTION
## Summary
- allow `cac_rud()` to accept `x` and `D` parameters
- automatically compute standard errors from item metadata when `se` is missing
- update examples and documentation

## Testing
- ❌ `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c4bc04950832ea901987d17189c42